### PR TITLE
Update execution counts and add re-categorization functionality for 'Others' expenses in Jupyter notebook

### DIFF
--- a/test.ipynb
+++ b/test.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "fffc729b",
    "metadata": {},
    "outputs": [
@@ -10,11 +10,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Collecting PyPDF2\n",
-      "  Downloading pypdf2-3.0.1-py3-none-any.whl (232 kB)\n",
-      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m232.6/232.6 kB\u001b[0m \u001b[31m3.7 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0ma \u001b[36m0:00:01\u001b[0m\n",
-      "\u001b[?25hInstalling collected packages: PyPDF2\n",
-      "Successfully installed PyPDF2-3.0.1\n"
+      "Requirement already satisfied: PyPDF2 in /Users/shreyuu/miniconda3/envs/ml/lib/python3.10/site-packages (3.0.1)\n",
+      "Note: you may need to restart the kernel to use updated packages.\n"
      ]
     }
    ],
@@ -76,7 +73,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 4,
    "id": "cfc95d51",
    "metadata": {},
    "outputs": [
@@ -114,7 +111,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 5,
    "id": "d018c600",
    "metadata": {},
    "outputs": [
@@ -165,7 +162,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 6,
    "id": "db7c52cd",
    "metadata": {},
    "outputs": [],
@@ -202,7 +199,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 8,
    "id": "b54f815c",
    "metadata": {},
    "outputs": [
@@ -251,7 +248,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 9,
    "id": "25e1c66c",
    "metadata": {},
    "outputs": [
@@ -276,7 +273,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 10,
    "id": "a40c1a3a",
    "metadata": {},
    "outputs": [
@@ -310,7 +307,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 11,
    "id": "57848565",
    "metadata": {},
    "outputs": [
@@ -332,6 +329,59 @@
     "plt.ylabel(\"Amount (₹)\")\n",
     "plt.legend(title=\"Category\")\n",
     "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "57cbd0f3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "others_df = df[df[\"Category\"] == \"Others\"]\n",
+    "print(\"Expenses categorized as 'Others':\")\n",
+    "for idx, row in others_df.iterrows():\n",
+    "    print(f\"{idx}: {row['Date']} | {row['Withdrawal']} | {row['Narration']}\")\n",
+    "\n",
+    "# Optionally, let user re-categorize\n",
+    "for idx, row in others_df.iterrows():\n",
+    "    print(f\"\\nIndex: {idx}\\nDate: {row['Date']}\\nAmount: {row['Withdrawal']}\\nNarration: {row['Narration']}\")\n",
+    "    new_cat = input(\"Enter new category (or press Enter to keep as 'Others'): \").strip()\n",
+    "    if new_cat:\n",
+    "        df.at[idx, \"Category\"] = new_cat\n",
+    "\n",
+    "print(\"Updated categories for 'Others':\")\n",
+    "print(df.loc[others_df.index][[\"Date\", \"Withdrawal\", \"Narration\", \"Category\"]])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "859b8e25",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Group 'Others' by narration prefix (first part before first space or '-')\n",
+    "import re\n",
+    "\n",
+    "others_df = df[df[\"Category\"] == \"Others\"].copy()\n",
+    "\n",
+    "def get_prefix(narration):\n",
+    "    # Extract up to first '-' or space (customize as needed)\n",
+    "    match = re.match(r\"([A-Z0-9& ]+?)[- ]\", narration.upper())\n",
+    "    return match.group(1).strip() if match else narration[:20]\n",
+    "\n",
+    "others_df[\"Prefix\"] = others_df[\"Narration\"].apply(get_prefix)\n",
+    "\n",
+    "for prefix, group in others_df.groupby(\"Prefix\"):\n",
+    "    print(f\"\\nGroup: {prefix}\")\n",
+    "    print(group[[\"Date\", \"Withdrawal\", \"Narration\"]])\n",
+    "    new_cat = input(f\"Enter category for group '{prefix}' (or press Enter to skip): \").strip()\n",
+    "    if new_cat:\n",
+    "        df.loc[group.index, \"Category\"] = new_cat\n",
+    "\n",
+    "print(\"Updated categories for grouped 'Others':\")\n",
+    "print(df.loc[others_df.index][[\"Date\", \"Withdrawal\", \"Narration\", \"Category\"]])"
    ]
   }
  ],


### PR DESCRIPTION
This pull request updates the `test.ipynb` notebook with minor execution count adjustments and significant new functionality for handling and re-categorizing expenses labeled as "Others". The most important changes are grouped below.

Enhancements for expense categorization:

* Added a new cell to display all expenses categorized as "Others" and allow the user to interactively re-categorize them using input prompts.
* Introduced a cell that groups "Others" expenses by narration prefix and lets the user assign a new category to each group, streamlining the re-categorization process.

Notebook execution and output updates:

* Updated execution counts for several code cells to reflect the latest run order, ensuring notebook consistency. [[1]](diffhunk://#diff-9225f374cff3d43695023abb36e68226769a5dd6156fbdfdfd7539ecf72c1abaL5-R14) [[2]](diffhunk://#diff-9225f374cff3d43695023abb36e68226769a5dd6156fbdfdfd7539ecf72c1abaL79-R76) [[3]](diffhunk://#diff-9225f374cff3d43695023abb36e68226769a5dd6156fbdfdfd7539ecf72c1abaL117-R114) [[4]](diffhunk://#diff-9225f374cff3d43695023abb36e68226769a5dd6156fbdfdfd7539ecf72c1abaL168-R165) [[5]](diffhunk://#diff-9225f374cff3d43695023abb36e68226769a5dd6156fbdfdfd7539ecf72c1abaL205-R202) [[6]](diffhunk://#diff-9225f374cff3d43695023abb36e68226769a5dd6156fbdfdfd7539ecf72c1abaL254-R251) [[7]](diffhunk://#diff-9225f374cff3d43695023abb36e68226769a5dd6156fbdfdfd7539ecf72c1abaL279-R276) [[8]](diffhunk://#diff-9225f374cff3d43695023abb36e68226769a5dd6156fbdfdfd7539ecf72c1abaL313-R310)
* Modified the package installation output to show that `PyPDF2` is already installed, replacing the previous installation logs.